### PR TITLE
Mostrar clientes ordenados en la pantalla de creación

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -348,48 +348,24 @@ th {
   margin-bottom: 1rem;
 }
 
-.listado-clientes__lista ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+.listado-clientes__select {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 1rem;
+  color: #000;
+  background-color: #fff;
 }
 
-.listado-clientes__lista li {
-  padding: 12px 0;
-  border-bottom: 1px solid #eee;
+.listado-clientes__select:disabled {
+  background-color: #f5f5f5;
+  color: #777;
 }
 
-.listado-clientes__lista li:last-child {
-  border-bottom: none;
-}
-
-.listado-clientes__lista strong {
-  display: block;
-  font-size: 1.1rem;
-}
-
-.listado-clientes__detalles {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin-top: 6px;
-  color: #555;
+.listado-clientes__nota {
+  margin-top: 12px;
   font-size: 0.9rem;
-}
-
-.listado-clientes__problemas {
-  margin-top: 8px;
-  display: inline-block;
-  padding: 4px 8px;
-  border-radius: 999px;
-  background-color: rgba(255, 102, 102, 0.15);
-  color: #a40000;
-  font-weight: 600;
-  font-size: 0.85rem;
-}
-
-.listado-clientes__lista p {
-  margin: 0;
   color: #555;
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -334,6 +334,65 @@ th {
   gap: 1rem;
 }
 
+.listado-clientes {
+  background-color: white;
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  margin-top: 20px;
+  color: #000;
+}
+
+.listado-clientes h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.listado-clientes__lista ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.listado-clientes__lista li {
+  padding: 12px 0;
+  border-bottom: 1px solid #eee;
+}
+
+.listado-clientes__lista li:last-child {
+  border-bottom: none;
+}
+
+.listado-clientes__lista strong {
+  display: block;
+  font-size: 1.1rem;
+}
+
+.listado-clientes__detalles {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 6px;
+  color: #555;
+  font-size: 0.9rem;
+}
+
+.listado-clientes__problemas {
+  margin-top: 8px;
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background-color: rgba(255, 102, 102, 0.15);
+  color: #a40000;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.listado-clientes__lista p {
+  margin: 0;
+  color: #555;
+}
+
 .formulario input[type="text"],
 .formulario input[type="tel"],
 .formulario input[type="number"],

--- a/crear_cliente.html
+++ b/crear_cliente.html
@@ -30,6 +30,13 @@
 
       <button onclick="crearCliente()">💾 Guardar Cliente</button>
     </div>
+
+    <section class="listado-clientes">
+      <h2>📋 Clientes registrados</h2>
+      <div id="lista-clientes" class="listado-clientes__lista">
+        <p>Cargando clientes...</p>
+      </div>
+    </section>
   </main>
 
   <div id="footer"></div>
@@ -38,7 +45,66 @@
     (async () => {
       document.getElementById("header").innerHTML = await fetch("header.html").then(r => r.text());
       document.getElementById("footer").innerHTML = await fetch("footer.html").then(r => r.text());
+      await cargarClientes();
     })();
+
+    async function cargarClientes() {
+      const contenedor = document.getElementById('lista-clientes');
+      if (!contenedor) return;
+
+      contenedor.innerHTML = '<p>Cargando clientes...</p>';
+
+      const { data, error } = await supabase
+        .from('CLIENTE')
+        .select('id, nombre, telefono, direccion, problemas')
+        .order('nombre', { ascending: true });
+
+      if (error) {
+        console.error('Error al cargar clientes:', error);
+        contenedor.innerHTML = '<p>Error al cargar clientes.</p>';
+        return;
+      }
+
+      if (!data || data.length === 0) {
+        contenedor.innerHTML = '<p>No hay clientes registrados.</p>';
+        return;
+      }
+
+      const lista = document.createElement('ul');
+
+      data.forEach(cliente => {
+        const item = document.createElement('li');
+
+        const nombre = document.createElement('strong');
+        nombre.textContent = cliente.nombre;
+        item.appendChild(nombre);
+
+        const detalles = document.createElement('div');
+        detalles.className = 'listado-clientes__detalles';
+
+        const telefono = document.createElement('span');
+        telefono.textContent = `📞 ${cliente.telefono}`;
+        detalles.appendChild(telefono);
+
+        const direccion = document.createElement('span');
+        direccion.textContent = `📍 ${cliente.direccion}`;
+        detalles.appendChild(direccion);
+
+        item.appendChild(detalles);
+
+        if (cliente.problemas) {
+          const etiquetaProblemas = document.createElement('span');
+          etiquetaProblemas.className = 'listado-clientes__problemas';
+          etiquetaProblemas.textContent = '⚠️ Problemas';
+          item.appendChild(etiquetaProblemas);
+        }
+
+        lista.appendChild(item);
+      });
+
+      contenedor.innerHTML = '';
+      contenedor.appendChild(lista);
+    }
 
     async function crearCliente() {
       const nombre = document.getElementById('nombre').value.trim();

--- a/crear_cliente.html
+++ b/crear_cliente.html
@@ -33,9 +33,12 @@
 
     <section class="listado-clientes">
       <h2>📋 Clientes registrados</h2>
-      <div id="lista-clientes" class="listado-clientes__lista">
-        <p>Cargando clientes...</p>
-      </div>
+      <select id="cliente-consulta" class="listado-clientes__select">
+        <option value="">Cargando clientes...</option>
+      </select>
+      <p class="listado-clientes__nota">
+        Esta lista desplegable es solo informativa; seleccionar un cliente no realiza ninguna acción.
+      </p>
     </section>
   </main>
 
@@ -49,61 +52,37 @@
     })();
 
     async function cargarClientes() {
-      const contenedor = document.getElementById('lista-clientes');
-      if (!contenedor) return;
+      const select = document.getElementById('cliente-consulta');
+      if (!select) return;
 
-      contenedor.innerHTML = '<p>Cargando clientes...</p>';
+      select.innerHTML = '<option value="">Cargando clientes...</option>';
+      select.disabled = true;
 
       const { data, error } = await supabase
         .from('CLIENTE')
-        .select('id, nombre, telefono, direccion, problemas')
+        .select('id, nombre')
         .order('nombre', { ascending: true });
 
       if (error) {
         console.error('Error al cargar clientes:', error);
-        contenedor.innerHTML = '<p>Error al cargar clientes.</p>';
+        select.innerHTML = '<option value="">Error al cargar clientes</option>';
         return;
       }
 
       if (!data || data.length === 0) {
-        contenedor.innerHTML = '<p>No hay clientes registrados.</p>';
+        select.innerHTML = '<option value="">No hay clientes registrados</option>';
         return;
       }
 
-      const lista = document.createElement('ul');
+      select.disabled = false;
+      select.innerHTML = '<option value="">Clientes registrados (solo consulta)</option>';
 
       data.forEach(cliente => {
-        const item = document.createElement('li');
-
-        const nombre = document.createElement('strong');
-        nombre.textContent = cliente.nombre;
-        item.appendChild(nombre);
-
-        const detalles = document.createElement('div');
-        detalles.className = 'listado-clientes__detalles';
-
-        const telefono = document.createElement('span');
-        telefono.textContent = `📞 ${cliente.telefono}`;
-        detalles.appendChild(telefono);
-
-        const direccion = document.createElement('span');
-        direccion.textContent = `📍 ${cliente.direccion}`;
-        detalles.appendChild(direccion);
-
-        item.appendChild(detalles);
-
-        if (cliente.problemas) {
-          const etiquetaProblemas = document.createElement('span');
-          etiquetaProblemas.className = 'listado-clientes__problemas';
-          etiquetaProblemas.textContent = '⚠️ Problemas';
-          item.appendChild(etiquetaProblemas);
-        }
-
-        lista.appendChild(item);
+        const option = document.createElement('option');
+        option.value = cliente.id;
+        option.textContent = cliente.nombre;
+        select.appendChild(option);
       });
-
-      contenedor.innerHTML = '';
-      contenedor.appendChild(lista);
     }
 
     async function crearCliente() {

--- a/registrar_venta.html
+++ b/registrar_venta.html
@@ -79,7 +79,7 @@
       const { data, error } = await supabase
         .from('CLIENTE')
         .select('*')
-        .order('created_at', { ascending: false }); // 🔁 Orden por fecha de creación (desc)
+        .order('nombre', { ascending: true });
 
       if (error) return alert('Error cargando clientes');
       const select = document.getElementById('cliente-select');


### PR DESCRIPTION
## Summary
- mostrar la lista de clientes existentes en crear_cliente.html ordenada alfabéticamente desde Supabase
- añadir estilos dedicados al listado de clientes para mantener la presentación consistente

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca13353cc483278f09cc7c74c69826