### PR TITLE
Agregar autenticación por código verificado

### DIFF
--- a/agregar.html
+++ b/agregar.html
@@ -6,9 +6,8 @@
   <link rel="stylesheet" href="assets/style.css">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script src="js/supabase-client.js"></script>
+  <script src="js/auth.js"></script>
 </head>
-<body>
-
 <body>
 
 <div id="header"></div>
@@ -44,9 +43,13 @@
 
 <script>
 (async () => {
+  const sesion = await portalAuth.asegurarSesionActiva();
+  if (!sesion) return;
+
   try {
     const header = await fetch('header.html').then(r => r.text());
     document.getElementById("header").innerHTML = header;
+    portalAuth.refrescarIndicadoresSesion();
     const footer = await fetch('footer.html').then(r => r.text());
     document.getElementById("footer").innerHTML = footer;
     generarTallasPorDefecto();

--- a/assets/style.css
+++ b/assets/style.css
@@ -8,8 +8,105 @@ body {
   color: #000;
 }
 
+body.login-page {
+  max-width: none;
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at top, #ffffff 0%, #f3f4f6 45%, #e5e7eb 100%);
+}
+
 h1 {
   margin-bottom: 20px;
+}
+
+.login-wrapper {
+  width: 100%;
+  padding: 40px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.login-card {
+  width: 100%;
+  max-width: 420px;
+  padding: 40px 32px;
+  border-radius: 16px;
+  background: #ffffff;
+  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  text-align: center;
+}
+
+.login-card h1 {
+  margin-bottom: 0;
+  font-size: 2rem;
+  color: #111827;
+}
+
+.login-description {
+  color: #4b5563;
+  font-size: 1rem;
+  margin: 0;
+}
+
+.login-card form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  text-align: left;
+}
+
+.login-card label {
+  font-weight: 600;
+  color: #111827;
+}
+
+.login-card input {
+  padding: 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.login-card input:focus {
+  border-color: #111827;
+  box-shadow: 0 0 0 3px rgba(17, 24, 39, 0.15);
+  outline: none;
+}
+
+.login-card button {
+  width: 100%;
+  padding: 12px;
+  font-size: 1rem;
+  font-weight: 700;
+  border-radius: 8px;
+}
+
+.login-feedback {
+  min-height: 24px;
+  font-size: 0.95rem;
+}
+
+.login-feedback.error {
+  color: #b91c1c;
+}
+
+.login-feedback.success {
+  color: #15803d;
+}
+
+.login-help {
+  font-size: 0.9rem;
+  color: #6b7280;
+  margin: 0;
 }
 
 /* ===== Botones globales ===== */
@@ -83,6 +180,32 @@ button:hover,
 #contador-resultados {
   margin-bottom: 20px;
   font-weight: bold;
+  color: #000;
+}
+
+.venta-opciones {
+  margin: 16px 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.venta-opciones .campo-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 180px;
+}
+
+.venta-opciones label {
+  font-weight: 600;
+}
+
+.venta-opciones input {
+  padding: 8px 10px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background-color: #fff;
   color: #000;
 }
 
@@ -245,10 +368,18 @@ th {
   margin-bottom: 20px;
 }
 
-.nav-menu {
+.header-content {
   max-width: 1200px;
-  margin: auto;
+  margin: 0 auto;
   padding: 0 20px;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.nav-menu {
+  flex: 1;
 }
 
 .nav-list,
@@ -263,6 +394,49 @@ th {
   display: flex;
   justify-content: flex-start;
   gap: 30px;
+}
+
+.session-info {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: #fff;
+  font-size: 0.95rem;
+  margin-left: auto;
+}
+
+.session-alias {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.logout-button {
+  display: none;
+  background: #dc2626;
+  border: none;
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.logout-button:hover {
+  background: #b91c1c;
+}
+
+@media (max-width: 768px) {
+  .nav-list {
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+
+  .session-info {
+    width: 100%;
+    justify-content: space-between;
+    margin-left: 0;
+  }
 }
 
 .nav-item {
@@ -332,6 +506,41 @@ th {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.listado-clientes {
+  background-color: white;
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  margin-top: 20px;
+  color: #000;
+}
+
+.listado-clientes h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.listado-clientes__select {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 1rem;
+  color: #000;
+  background-color: #fff;
+}
+
+.listado-clientes__select:disabled {
+  background-color: #f5f5f5;
+  color: #777;
+}
+
+.listado-clientes__nota {
+  margin-top: 12px;
+  font-size: 0.9rem;
+  color: #555;
 }
 
 .formulario input[type="text"],

--- a/crear_cliente.html
+++ b/crear_cliente.html
@@ -6,6 +6,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script src="js/supabase-client.js"></script>
   <link rel="stylesheet" href="assets/style.css">
+  <script src="js/auth.js"></script>
 </head>
 <body>
   <div id="header"></div>
@@ -30,15 +31,64 @@
 
       <button onclick="crearCliente()">💾 Guardar Cliente</button>
     </div>
+
+    <section class="listado-clientes">
+      <h2>📋 Clientes registrados</h2>
+      <select id="cliente-consulta" class="listado-clientes__select">
+        <option value="">Cargando clientes...</option>
+      </select>
+      <p class="listado-clientes__nota">
+        Esta lista desplegable es solo informativa; seleccionar un cliente no realiza ninguna acción.
+      </p>
+    </section>
   </main>
 
   <div id="footer"></div>
 
   <script>
     (async () => {
+      const sesion = await portalAuth.asegurarSesionActiva();
+      if (!sesion) return;
+
       document.getElementById("header").innerHTML = await fetch("header.html").then(r => r.text());
+      portalAuth.refrescarIndicadoresSesion();
       document.getElementById("footer").innerHTML = await fetch("footer.html").then(r => r.text());
+      await cargarClientes();
     })();
+
+    async function cargarClientes() {
+      const select = document.getElementById('cliente-consulta');
+      if (!select) return;
+
+      select.innerHTML = '<option value="">Cargando clientes...</option>';
+      select.disabled = true;
+
+      const { data, error } = await supabase
+        .from('CLIENTE')
+        .select('id, nombre')
+        .order('nombre', { ascending: true });
+
+      if (error) {
+        console.error('Error al cargar clientes:', error);
+        select.innerHTML = '<option value="">Error al cargar clientes</option>';
+        return;
+      }
+
+      if (!data || data.length === 0) {
+        select.innerHTML = '<option value="">No hay clientes registrados</option>';
+        return;
+      }
+
+      select.disabled = false;
+      select.innerHTML = '<option value="">Clientes registrados (solo consulta)</option>';
+
+      data.forEach(cliente => {
+        const option = document.createElement('option');
+        option.value = cliente.id;
+        option.textContent = cliente.nombre;
+        select.appendChild(option);
+      });
+    }
 
     async function crearCliente() {
       const nombre = document.getElementById('nombre').value.trim();

--- a/eliminar.html
+++ b/eliminar.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="assets/style.css">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script src="js/supabase-client.js"></script>
+  <script src="js/auth.js"></script>
   <style>
     .eliminar-container {
       font-family: sans-serif;
@@ -78,8 +79,12 @@
 
   <script>
     (async () => {
+      const sesion = await portalAuth.asegurarSesionActiva();
+      if (!sesion) return;
+
       try {
         document.getElementById("header").innerHTML = await fetch('header.html').then(r => r.text());
+        portalAuth.refrescarIndicadoresSesion();
         document.getElementById("footer").innerHTML = await fetch('footer.html').then(r => r.text());
         cargarInventario();
       } catch (e) {

--- a/header.html
+++ b/header.html
@@ -1,30 +1,36 @@
 <header class="main-header">
-  <nav class="nav-menu">
-    <ul class="nav-list">
-      <li class="nav-item">
-        <button type="button">Ventas</button>
-        <ul class="dropdown-content">
-          <li><a href="registrar_venta.html">Registrar Venta</a></li>
-          <li><a href="ver_ventas.html">Ver Ventas</a></li>
-          <li><a href="modificar_venta.html">Modificar Ventas</a></li>
-        </ul>
-      </li>
-      <li class="nav-item">
-        <button type="button">Inventario</button>
-        <ul class="dropdown-content">
-          <li><a href="inventario.html">Inventario</a></li>
-          <li><a href="agregar.html">Agregar</a></li>
-          <li><a href="modificar.html">Modificación</a></li>
-          <li><a href="eliminar.html">Eliminar</a></li>
-        </ul>
-      </li>
-      <li class="nav-item">
-        <button type="button">Clientes</button>
-        <ul class="dropdown-content">
-          <li><a href="crear_cliente.html">Crear Cliente</a></li>
-          <li><a href="modificar_cliente.html">Modificar Cliente</a></li>
-        </ul>
-      </li>
-    </ul>
-  </nav>
+  <div class="header-content">
+    <nav class="nav-menu">
+      <ul class="nav-list">
+        <li class="nav-item">
+          <button type="button">Ventas</button>
+          <ul class="dropdown-content">
+            <li><a href="registrar_venta.html">Registrar Venta</a></li>
+            <li><a href="ver_ventas.html">Ver Ventas</a></li>
+            <li><a href="modificar_venta.html">Modificar Ventas</a></li>
+          </ul>
+        </li>
+        <li class="nav-item">
+          <button type="button">Inventario</button>
+          <ul class="dropdown-content">
+            <li><a href="inventario.html">Inventario</a></li>
+            <li><a href="agregar.html">Agregar</a></li>
+            <li><a href="modificar.html">Modificación</a></li>
+            <li><a href="eliminar.html">Eliminar</a></li>
+          </ul>
+        </li>
+        <li class="nav-item">
+          <button type="button">Clientes</button>
+          <ul class="dropdown-content">
+            <li><a href="crear_cliente.html">Crear Cliente</a></li>
+            <li><a href="modificar_cliente.html">Modificar Cliente</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+    <div class="session-info">
+      <span id="session-user-alias" class="session-alias"></span>
+      <button type="button" class="logout-button" data-logout>Cerrar sesión</button>
+    </div>
+  </div>
 </header>

--- a/index.html
+++ b/index.html
@@ -1,11 +1,30 @@
-<!-- index.html -->
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <meta http-equiv="refresh" content="0; url=inventario.html" />
+  <meta charset="UTF-8" />
   <title>Redirigiendo...</title>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+  <script src="js/supabase-client.js"></script>
+  <script src="js/auth.js"></script>
 </head>
 <body>
-  Si no redirige automáticamente, <a href="inventario.html">haz clic aquí</a>.
+  <p>Redirigiendo…</p>
+  <script>
+    (async () => {
+      if (!window.portalAuth) {
+        window.location.replace('login.html');
+        return;
+      }
+
+      try {
+        const sesion = await portalAuth.obtenerSesionActual({ revalidate: false });
+        const destino = sesion ? 'inventario.html' : 'login.html';
+        window.location.replace(destino);
+      } catch (error) {
+        console.error('No fue posible determinar la sesión activa', error);
+        window.location.replace('login.html');
+      }
+    })();
+  </script>
 </body>
 </html>

--- a/inventario.html
+++ b/inventario.html
@@ -6,6 +6,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.7.1/jszip.min.js"></script>
   <script src="js/supabase-client.js"></script>
+  <script src="js/auth.js"></script>
   <link rel="stylesheet" href="assets/style.css">
   <style>
     #modal-progreso {
@@ -80,8 +81,13 @@
     let inventarioCompleto = [];
 
     (async () => {
+      const sesion = await portalAuth.asegurarSesionActiva();
+      if (!sesion) return;
+
       document.getElementById("header").innerHTML = await fetch('header.html').then(r => r.text());
+      portalAuth.refrescarIndicadoresSesion();
       document.getElementById("footer").innerHTML = await fetch('footer.html').then(r => r.text());
+
       await obtenerInventario();
       cargarInventario();
     })();

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,0 +1,232 @@
+(() => {
+  const STORAGE_KEY = 'portalSesionVerificada';
+  const SESSION_DURATION_MS = 12 * 60 * 60 * 1000; // 12 horas
+  const REVALIDATION_INTERVAL_MS = 5 * 60 * 1000; // 5 minutos
+
+  const getCurrentFile = () => {
+    const parts = window.location.pathname.split('/');
+    const last = parts[parts.length - 1];
+    return (last || 'index.html').toLowerCase();
+  };
+
+  const isLoginPage = () => getCurrentFile() === 'login.html';
+
+  const buildNextParam = () => {
+    const path = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    return encodeURIComponent(path);
+  };
+
+  const sanitizeDestination = (rawNext) => {
+    if (!rawNext) return 'inventario.html';
+
+    try {
+      const decoded = decodeURIComponent(rawNext).trim();
+      if (!decoded) return 'inventario.html';
+      if (/^https?:\/\//i.test(decoded) || decoded.startsWith('//')) {
+        return 'inventario.html';
+      }
+      if (decoded.includes('..')) {
+        return 'inventario.html';
+      }
+      return decoded;
+    } catch (error) {
+      console.error('No se pudo interpretar el parámetro next', error);
+      return 'inventario.html';
+    }
+  };
+
+  const readSessionWithoutValidation = () => {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+
+    try {
+      return JSON.parse(raw);
+    } catch (error) {
+      console.warn('Sesión inválida en almacenamiento local, limpiando.', error);
+      localStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+  };
+
+  const persistSession = (session) => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+    refreshSessionIndicators(session);
+  };
+
+  const clearSession = () => {
+    localStorage.removeItem(STORAGE_KEY);
+    refreshSessionIndicators(null);
+  };
+
+  const refreshSessionIndicators = (sessionParam) => {
+    const session = sessionParam || readSessionWithoutValidation();
+    const aliasElement = document.getElementById('session-user-alias');
+    const logoutButton = document.querySelector('[data-logout]');
+
+    if (aliasElement) {
+      if (session && session.alias) {
+        aliasElement.textContent = `🔐 ${session.alias}`;
+      } else if (session) {
+        aliasElement.textContent = '🔐 Acceso activo';
+      } else {
+        aliasElement.textContent = '';
+      }
+    }
+
+    if (logoutButton) {
+      logoutButton.style.display = session ? 'inline-flex' : 'none';
+    }
+  };
+
+  const hashVerificationCode = async (code) => {
+    const encoder = new TextEncoder();
+    const data = encoder.encode(code);
+    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+  };
+
+  const fetchCodeRecord = async (hash) => {
+    // Espera que la tabla CODIGOS_ACCESO tenga las columnas: hash (SHA-256 en hex), alias (opcional) y activo (boolean).
+    const { data, error } = await supabase
+      .from('CODIGOS_ACCESO')
+      .select('id, alias')
+      .eq('hash', hash)
+      .eq('activo', true)
+      .maybeSingle();
+
+    if (error && error.code !== 'PGRST116') {
+      throw error;
+    }
+
+    return data || null;
+  };
+
+  const obtainCurrentSession = async ({ revalidate = true } = {}) => {
+    const stored = readSessionWithoutValidation();
+    if (!stored || !stored.token || !stored.expira) {
+      clearSession();
+      return null;
+    }
+
+    if (Date.now() > stored.expira) {
+      clearSession();
+      return null;
+    }
+
+    if (!revalidate) {
+      return stored;
+    }
+
+    const lastValidation = stored.ultimaValidacion || 0;
+    if (Date.now() - lastValidation < REVALIDATION_INTERVAL_MS) {
+      return stored;
+    }
+
+    const record = await fetchCodeRecord(stored.token);
+    if (!record) {
+      clearSession();
+      return null;
+    }
+
+    const refreshed = {
+      token: stored.token,
+      alias: record.alias || stored.alias || '',
+      expira: Date.now() + SESSION_DURATION_MS,
+      ultimaValidacion: Date.now()
+    };
+    persistSession(refreshed);
+    return refreshed;
+  };
+
+  const ensureActiveSession = async () => {
+    if (typeof supabase === 'undefined') {
+      console.error('Supabase no está disponible. Verifica la carga de supabase-client.js.');
+      return false;
+    }
+
+    if (isLoginPage()) {
+      const existing = await obtainCurrentSession({ revalidate: false });
+      if (existing) {
+        const destination = getSafeDestination();
+        window.location.replace(destination);
+        return false;
+      }
+      return true;
+    }
+
+    try {
+      const session = await obtainCurrentSession();
+      if (!session) {
+        redirectToLogin();
+        return false;
+      }
+      refreshSessionIndicators(session);
+      return session;
+    } catch (error) {
+      console.error('No se pudo validar la sesión activa', error);
+      alert('No se pudo validar tu sesión. Por favor ingresa nuevamente.');
+      redirectToLogin();
+      return false;
+    }
+  };
+
+  const startSessionWithCode = async (code) => {
+    const hash = await hashVerificationCode(code);
+    const record = await fetchCodeRecord(hash);
+
+    if (!record) {
+      return { ok: false, reason: 'invalid' };
+    }
+
+    const session = {
+      token: hash,
+      alias: record.alias || '',
+      expira: Date.now() + SESSION_DURATION_MS,
+      ultimaValidacion: Date.now()
+    };
+
+    persistSession(session);
+    return { ok: true, session };
+  };
+
+  const getSafeDestination = () => {
+    const params = new URLSearchParams(window.location.search);
+    const nextParam = params.get('next');
+    const safePath = sanitizeDestination(nextParam);
+    return safePath;
+  };
+
+  const redirectToLogin = () => {
+    if (isLoginPage()) return;
+    const nextValue = buildNextParam();
+    window.location.replace(`login.html?next=${nextValue}`);
+  };
+
+  const logout = (redirect = true) => {
+    clearSession();
+    if (redirect) {
+      window.location.replace('login.html');
+    }
+  };
+
+  document.addEventListener('click', (event) => {
+    if (event.target.matches('[data-logout]')) {
+      event.preventDefault();
+      logout(true);
+    }
+  });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    refreshSessionIndicators();
+  });
+
+  window.portalAuth = {
+    asegurarSesionActiva: ensureActiveSession,
+    iniciarSesionConCodigo: startSessionWithCode,
+    cerrarSesion: logout,
+    refrescarIndicadoresSesion: refreshSessionIndicators,
+    obtenerSesionActual: obtainCurrentSession,
+    obtenerDestinoSeguro: getSafeDestination
+  };
+})();

--- a/js/login.js
+++ b/js/login.js
@@ -1,0 +1,74 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  if (!window.portalAuth) {
+    console.error('El módulo de autenticación no está disponible.');
+    return;
+  }
+
+  const continuar = await portalAuth.asegurarSesionActiva();
+  if (!continuar) {
+    return;
+  }
+
+  const form = document.getElementById('login-form');
+  const codeInput = document.getElementById('verification-code');
+  const feedback = document.getElementById('login-feedback');
+  const submitButton = document.getElementById('login-submit');
+
+  if (!form || !codeInput || !feedback || !submitButton) {
+    console.error('Faltan elementos requeridos en la pantalla de acceso.');
+    return;
+  }
+
+  const setFeedback = (message, type = '') => {
+    feedback.textContent = message;
+    feedback.classList.remove('error', 'success', 'info');
+    if (type) {
+      feedback.classList.add(type);
+    }
+  };
+
+  codeInput.addEventListener('input', () => {
+    if (feedback.textContent) {
+      setFeedback('');
+    }
+  });
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const code = codeInput.value.trim();
+
+    if (!code) {
+      setFeedback('Ingresa el código de verificación proporcionado.', 'error');
+      codeInput.focus();
+      return;
+    }
+
+    submitButton.disabled = true;
+    const originalText = submitButton.textContent;
+    submitButton.textContent = 'Validando...';
+
+    try {
+      const result = await portalAuth.iniciarSesionConCodigo(code);
+      if (result.ok) {
+        setFeedback('Acceso concedido. Redirigiendo...', 'success');
+        const destino = portalAuth.obtenerDestinoSeguro();
+        setTimeout(() => {
+          window.location.replace(destino);
+        }, 400);
+        return;
+      }
+
+      if (result.reason === 'invalid') {
+        setFeedback('El código no es válido o está inactivo.', 'error');
+      } else {
+        setFeedback('No se pudo validar el código. Intenta nuevamente.', 'error');
+      }
+    } catch (error) {
+      console.error('Error al iniciar sesión con código', error);
+      setFeedback('Ocurrió un error al validar el código. Vuelve a intentarlo.', 'error');
+    } finally {
+      submitButton.disabled = false;
+      submitButton.textContent = originalText;
+    }
+  });
+});

--- a/login.html
+++ b/login.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Acceso seguro - ZAPATONGT</title>
+  <link rel="stylesheet" href="assets/style.css">
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+  <script src="js/supabase-client.js"></script>
+  <script src="js/auth.js"></script>
+</head>
+<body class="login-page">
+  <div class="login-wrapper">
+    <div class="login-card">
+      <h1>Acceso al portal</h1>
+      <p class="login-description">
+        Ingresa el código de verificación proporcionado para acceder a las herramientas internas.
+      </p>
+      <form id="login-form" autocomplete="one-time-code">
+        <label for="verification-code">Código de verificación</label>
+        <input type="password" id="verification-code" placeholder="Ej. ZAPATO-2024" required autofocus />
+        <button type="submit" id="login-submit">Ingresar</button>
+      </form>
+      <p id="login-feedback" class="login-feedback" role="alert"></p>
+      <p class="login-help">¿No tienes código? Contacta al administrador para generar uno nuevo y registrarlo en la tabla <strong>CODIGOS_ACCESO</strong>.</p>
+    </div>
+  </div>
+  <script src="js/login.js"></script>
+</body>
+</html>

--- a/modificar.html
+++ b/modificar.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="assets/style.css">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script src="js/supabase-client.js"></script>
+  <script src="js/auth.js"></script>
 </head>
 <body>
 <div id="header"></div>
@@ -41,7 +42,11 @@
 let inventarioCompleto = [];
 
 (async () => {
+  const sesion = await portalAuth.asegurarSesionActiva();
+  if (!sesion) return;
+
   document.getElementById("header").innerHTML = await fetch('header.html').then(r => r.text());
+  portalAuth.refrescarIndicadoresSesion();
   document.getElementById("footer").innerHTML = await fetch('footer.html').then(r => r.text());
   await obtenerInventario();
   cargarInventario();

--- a/modificar_cliente.html
+++ b/modificar_cliente.html
@@ -6,6 +6,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script src="js/supabase-client.js"></script>
   <link rel="stylesheet" href="assets/style.css">
+  <script src="js/auth.js"></script>
 </head>
 <body>
   <div id="header"></div>
@@ -39,8 +40,13 @@
 
   <script>
     (async () => {
+      const sesion = await portalAuth.asegurarSesionActiva();
+      if (!sesion) return;
+
       document.getElementById("header").innerHTML = await fetch("header.html").then(r => r.text());
+      portalAuth.refrescarIndicadoresSesion();
       document.getElementById("footer").innerHTML = await fetch("footer.html").then(r => r.text());
+      cargarClientes();
     })();
 
     async function cargarClientes() {
@@ -97,8 +103,6 @@
         window.location.href = 'registrar_venta.html';
       }
     }
-
-    cargarClientes();
   </script>
 </body>
 </html>

--- a/modificar_venta.html
+++ b/modificar_venta.html
@@ -6,6 +6,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script src="js/supabase-client.js"></script>
   <link rel="stylesheet" href="assets/style.css">
+  <script src="js/auth.js"></script>
 </head>
 <body>
   <div id="header"></div>
@@ -61,7 +62,11 @@
     let idsAEliminar = [];
 
     (async () => {
+      const sesion = await portalAuth.asegurarSesionActiva();
+      if (!sesion) return;
+
       document.getElementById("header").innerHTML = await fetch('header.html').then(r => r.text());
+      portalAuth.refrescarIndicadoresSesion();
       document.getElementById("footer").innerHTML = await fetch('footer.html').then(r => r.text());
       await cargarVentas();
       await cargarProductos();

--- a/registrar_venta.html
+++ b/registrar_venta.html
@@ -6,6 +6,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script src="js/supabase-client.js"></script>
   <link rel="stylesheet" href="assets/style.css">
+  <script src="js/auth.js"></script>
 </head>
 <body>
   <div id="header"></div>
@@ -52,12 +53,17 @@
     <tbody></tbody>
   </table>
 
-  <p id="total-carrito">Total: Q 0.00</p>
+  <p id="total-carrito">Total productos: Q 0.00</p>
 
-  <!-- Campo de ajuste debajo del total -->
-  <div style="margin-top: 1em;">
-    <label for="ajuste">🧾 Descuento o Recargo (Q):</label>
-    <input type="number" id="ajuste" value="0" step="5">
+  <div class="venta-opciones">
+    <div class="campo-form">
+      <label for="fecha-venta">🗓️ Fecha de la venta:</label>
+      <input type="date" id="fecha-venta">
+    </div>
+    <div class="campo-form">
+      <label for="total-final">💳 Total final (Q):</label>
+      <input type="number" id="total-final" min="0" step="0.01">
+    </div>
   </div>
 
   <button onclick="registrarVenta()">✅ Registrar Venta</button>
@@ -67,9 +73,39 @@
   <script>
     let productos = [];
     let seleccionados = [];
+    let totalFinalManual = false;
+    let totalBaseActual = 0;
+
+    const totalFinalInput = document.getElementById('total-final');
+    const fechaVentaInput = document.getElementById('fecha-venta');
+
+    if (fechaVentaInput) {
+      const hoy = new Date();
+      const anio = hoy.getFullYear();
+      const mes = String(hoy.getMonth() + 1).padStart(2, '0');
+      const dia = String(hoy.getDate()).padStart(2, '0');
+      fechaVentaInput.value = `${anio}-${mes}-${dia}`;
+    }
+
+    if (totalFinalInput) {
+      totalFinalInput.value = '0.00';
+      totalFinalInput.addEventListener('input', () => {
+        totalFinalManual = totalFinalInput.value.trim() !== '';
+      });
+      totalFinalInput.addEventListener('blur', () => {
+        if (totalFinalInput.value.trim() === '') {
+          totalFinalManual = false;
+          totalFinalInput.value = totalBaseActual.toFixed(2);
+        }
+      });
+    }
 
     (async () => {
+      const sesion = await portalAuth.asegurarSesionActiva();
+      if (!sesion) return;
+
       document.getElementById("header").innerHTML = await fetch('header.html').then(r => r.text());
+      portalAuth.refrescarIndicadoresSesion();
       document.getElementById("footer").innerHTML = await fetch('footer.html').then(r => r.text());
       await cargarClientes();
       await cargarProductos();
@@ -79,7 +115,7 @@
       const { data, error } = await supabase
         .from('CLIENTE')
         .select('*')
-        .order('created_at', { ascending: false }); // 🔁 Orden por fecha de creación (desc)
+        .order('nombre', { ascending: true });
 
       if (error) return alert('Error cargando clientes');
       const select = document.getElementById('cliente-select');
@@ -225,7 +261,22 @@
         tbody.appendChild(fila);
       });
 
-      document.getElementById('total-carrito').textContent = `Total: Q ${total.toFixed(2)}`;
+      const totalRedondeado = Number(total.toFixed(2));
+      totalBaseActual = totalRedondeado;
+      document.getElementById('total-carrito').textContent = `Total productos: Q ${totalRedondeado.toFixed(2)}`;
+
+      if (!totalFinalInput) return;
+
+      if (seleccionados.length === 0) {
+        totalFinalManual = false;
+        totalBaseActual = 0;
+        totalFinalInput.value = '0.00';
+        return;
+      }
+
+      if (!totalFinalManual) {
+        totalFinalInput.value = totalRedondeado.toFixed(2);
+      }
     }
 
     function quitarDelCarrito(index) {
@@ -238,13 +289,40 @@
       if (!clienteId) return alert('Selecciona un cliente');
       if (seleccionados.length === 0) return alert('No se agregaron productos');
 
-      const totalBase = seleccionados.reduce((s, d) => s + d.subtotal, 0);
-      const ajuste = parseFloat(document.getElementById('ajuste').value) || 0;
-      const total = totalBase + ajuste;
+      const totalBase = Number(seleccionados.reduce((s, d) => s + d.subtotal, 0).toFixed(2));
+
+      if (!totalFinalInput) return alert('No se encontró el campo de total final');
+
+      const totalFinal = Number(totalFinalInput.value);
+      if (!Number.isFinite(totalFinal) || totalFinal <= 0) {
+        return alert('Ingresa un total final válido');
+      }
+
+      const totalFinalRedondeado = Number(totalFinal.toFixed(2));
+      const ajuste = Number((totalFinalRedondeado - totalBase).toFixed(2));
+
+      if (!fechaVentaInput) return alert('No se encontró el campo de fecha');
+      const fechaSeleccionada = fechaVentaInput.value;
+      if (!fechaSeleccionada) {
+        return alert('Selecciona la fecha de la venta');
+      }
+
+      const partesFecha = fechaSeleccionada.split('-').map(Number);
+      if (partesFecha.length !== 3 || partesFecha.some(n => !Number.isFinite(n))) {
+        return alert('Fecha de venta inválida');
+      }
+
+      const [anio, mes, dia] = partesFecha;
+      if (!anio || !mes || !dia) {
+        return alert('Fecha de venta inválida');
+      }
+      const ahora = new Date();
+      const fechaVenta = new Date(anio, mes - 1, dia, ahora.getHours(), ahora.getMinutes(), ahora.getSeconds(), ahora.getMilliseconds());
+      const fechaVentaIso = fechaVenta.toISOString();
 
       const { data: venta, error: errorVenta } = await supabase
         .from('VENTAS')
-        .insert([{ cliente_id: clienteId, total: 0, ajuste }])
+        .insert([{ cliente_id: clienteId, total: totalFinalRedondeado, ajuste, created_at: fechaVentaIso }])
         .select()
         .single();
 
@@ -272,7 +350,7 @@
         }).eq('id', d.productoId);
       }
 
-      await supabase.from('VENTAS').update({ total }).eq('id', venta.id);
+      await supabase.from('VENTAS').update({ total: totalFinalRedondeado, ajuste }).eq('id', venta.id);
       alert('Venta registrada con éxito');
       location.reload();
     }

--- a/ver_ventas.html
+++ b/ver_ventas.html
@@ -6,6 +6,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script src="js/supabase-client.js"></script>
   <link rel="stylesheet" href="assets/style.css">
+  <script src="js/auth.js"></script>
 </head>
 <body>
   <div id="header"></div>
@@ -57,8 +58,13 @@
 
   <script>
     (async () => {
+      const sesion = await portalAuth.asegurarSesionActiva();
+      if (!sesion) return;
+
       document.getElementById("header").innerHTML = await fetch("header.html").then(r => r.text());
+      portalAuth.refrescarIndicadoresSesion();
       document.getElementById("footer").innerHTML = await fetch("footer.html").then(r => r.text());
+      cargarVentas('mes');
     })();
 
     function obtenerMesActual() {
@@ -192,8 +198,6 @@
       inputMesSelector.value = obtenerMesActual();
       inputMesSelector.addEventListener('change', () => cargarVentas('mes'));
     }
-
-    cargarVentas('mes');
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- agregar una pantalla de inicio de sesión que valida códigos hash almacenados en Supabase y crea sesiones locales con vigencia
- exponer un módulo de autenticación que protege cada vista, actualiza el encabezado con el usuario activo y permite cerrar la sesión
- ajustar el encabezado, estilos y la redirección inicial para exigir el inicio de sesión antes de entrar a las herramientas

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca13353cc483278f09cc7c74c69826