### PR TITLE
Agregar filtros por marca/talla tipo inventario en modificar.html

### DIFF
--- a/modificar.html
+++ b/modificar.html
@@ -19,11 +19,15 @@
   <input list="nombres" type="text" id="filtroNombre" placeholder="👟 Nombre">
   <datalist id="nombres"></datalist>
 
-  <input list="marcas" type="text" id="filtroMarca" placeholder="🏷️ Marca">
-  <datalist id="marcas"></datalist>
+  <div class="campo-filtro filtro-botones">
+    <span>🏷️ Marca</span>
+    <div id="marcas-botones" class="grupo-botones"></div>
+  </div>
 
-  <input list="tallas" type="text" id="filtroTalla" placeholder="📏 Talla">
-  <datalist id="tallas"></datalist>
+  <div class="campo-filtro filtro-botones">
+    <span>📏 Talla</span>
+    <div id="tallas-botones" class="grupo-botones"></div>
+  </div>
 
   <select id="filtroDisponible">
     <option value="todos" selected>📦 TODOS</option>
@@ -40,6 +44,8 @@
 
 <script>
 let inventarioCompleto = [];
+const filtrosMarcaSeleccionadas = new Set();
+const filtrosTallaSeleccionadas = new Set();
 
 (async () => {
   const sesion = await portalAuth.asegurarSesionActiva();
@@ -76,20 +82,31 @@ async function obtenerInventario() {
   }
 
   llenarDatalists(inventarioCompleto);
+  llenarFiltros(inventarioCompleto);
 }
 
 function cargarInventario() {
   const codigo = document.getElementById('filtroCodigo').value.trim().toLowerCase();
   const nombre = document.getElementById('filtroNombre').value.trim().toLowerCase();
-  const marca = document.getElementById('filtroMarca').value.trim().toLowerCase();
-  const talla = document.getElementById('filtroTalla').value.trim();
+  const marcasSeleccionadas = Array.from(filtrosMarcaSeleccionadas);
+  const tallasSeleccionadas = Array.from(filtrosTallaSeleccionadas);
   const disponibleFiltro = document.getElementById('filtroDisponible').value;
 
   let resultados = inventarioCompleto;
   if (codigo) resultados = resultados.filter(p => p.codigo.toLowerCase().includes(codigo));
   if (nombre) resultados = resultados.filter(p => p.nombre.toLowerCase().includes(nombre));
-  if (marca) resultados = resultados.filter(p => p.marca.toLowerCase().includes(marca));
-  if (talla) resultados = resultados.filter(p => p.talla == talla);
+  if (marcasSeleccionadas.length) {
+    resultados = resultados.filter(p => {
+      const marcaNormalizada = (p.marca ?? '').toString().trim().toLowerCase();
+      return marcasSeleccionadas.includes(marcaNormalizada);
+    });
+  }
+  if (tallasSeleccionadas.length) {
+    resultados = resultados.filter(p => {
+      const tallaNormalizada = String(p.talla ?? '').trim();
+      return tallasSeleccionadas.includes(tallaNormalizada);
+    });
+  }
   if (disponibleFiltro === 'disponibles') resultados = resultados.filter(p => p.disponible > 0);
 
   const agrupado = {};
@@ -154,8 +171,6 @@ function cargarInventario() {
 function llenarDatalists(data) {
   const codigos = [...new Set(data.map(i => i.codigo))];
   const nombres = [...new Set(data.map(i => i.nombre))];
-  const marcas = [...new Set(data.map(i => i.marca))];
-  const tallas = [...new Set(data.map(i => i.talla))];
 
   const setDatalist = (id, values) => {
     const list = document.getElementById(id);
@@ -169,16 +184,84 @@ function llenarDatalists(data) {
 
   setDatalist('codigos', codigos);
   setDatalist('nombres', nombres);
-  setDatalist('marcas', marcas);
-  setDatalist('tallas', tallas);
 }
 
 function limpiarFiltros() {
-  ['filtroCodigo', 'filtroNombre', 'filtroMarca', 'filtroTalla'].forEach(id => {
+  ['filtroCodigo', 'filtroNombre'].forEach(id => {
     document.getElementById(id).value = '';
   });
   document.getElementById('filtroDisponible').value = 'todos';
+  filtrosMarcaSeleccionadas.clear();
+  filtrosTallaSeleccionadas.clear();
+  actualizarBotones('marcas-botones', filtrosMarcaSeleccionadas);
+  actualizarBotones('tallas-botones', filtrosTallaSeleccionadas);
   cargarInventario();
+}
+
+function llenarFiltros(data) {
+  const marcas = new Set(data.map(i => i.marca));
+  const tallas = new Set(data.map(i => i.talla));
+  crearBotonesFiltro('marcas-botones', [...marcas]
+    .filter(v => v != null && String(v).trim() !== '')
+    .map(v => String(v))
+    .sort((a, b) => a.localeCompare(b)), 'marca');
+  crearBotonesFiltro('tallas-botones', [...tallas]
+    .filter(v => v != null && String(v).trim() !== '')
+    .map(v => String(v))
+    .sort((a, b) => {
+      const numA = parseFloat(a);
+      const numB = parseFloat(b);
+      if (!Number.isNaN(numA) && !Number.isNaN(numB)) return numA - numB;
+      return a.localeCompare(b);
+    }), 'talla');
+}
+
+function crearBotonesFiltro(containerId, valores, tipo) {
+  const contenedor = document.getElementById(containerId);
+  if (!contenedor) return;
+  contenedor.innerHTML = '';
+
+  valores.forEach(valor => {
+    const valorTexto = valor != null ? String(valor) : '';
+    const claveNormalizada = tipo === 'marca'
+      ? valorTexto.trim().toLowerCase()
+      : valorTexto.trim();
+
+    if (!claveNormalizada) return;
+
+    const boton = document.createElement('button');
+    boton.type = 'button';
+    boton.className = 'boton-filtro';
+    boton.dataset.valor = valorTexto;
+    boton.dataset.clave = claveNormalizada;
+    boton.textContent = valorTexto;
+    boton.addEventListener('click', () => {
+      const conjunto = tipo === 'marca' ? filtrosMarcaSeleccionadas : filtrosTallaSeleccionadas;
+      if (conjunto.has(claveNormalizada)) {
+        conjunto.delete(claveNormalizada);
+      } else {
+        conjunto.add(claveNormalizada);
+      }
+      actualizarBotones(containerId, conjunto);
+      cargarInventario();
+    });
+    contenedor.appendChild(boton);
+  });
+
+  const conjunto = tipo === 'marca' ? filtrosMarcaSeleccionadas : filtrosTallaSeleccionadas;
+  actualizarBotones(containerId, conjunto);
+}
+
+function actualizarBotones(containerId, valoresSeleccionados) {
+  const contenedor = document.getElementById(containerId);
+  if (!contenedor) return;
+  contenedor.querySelectorAll('button').forEach(boton => {
+    const claveBoton = boton.dataset.clave ?? boton.dataset.valor ?? '';
+    const activo = valoresSeleccionados instanceof Set
+      ? valoresSeleccionados.has(claveBoton)
+      : valoresSeleccionados === claveBoton;
+    boton.classList.toggle('activo', activo);
+  });
 }
 
 async function actualizarGrupo(boton) {


### PR DESCRIPTION
### Motivation
- Unificar la forma de filtrar por marca y talla en la vista de modificación con la que ya existe en `inventario.html` (botones multi-selección en lugar de `datalist`).
- Facilitar búsquedas por combinaciones de marca/talla disponibles al editar artículos.

### Description
- Reemplazados los `datalist` de marca/talla en `modificar.html` por contenedores de botones `#marcas-botones` y `#tallas-botones`.
- Añadidos estados de filtro `filtrosMarcaSeleccionadas` y `filtrosTallaSeleccionadas` y adaptado `cargarInventario()` para filtrar usando esos conjuntos.
- Implementadas las funciones auxiliares `llenarFiltros()`, `crearBotonesFiltro()` y `actualizarBotones()` y se invoca `llenarFiltros()` desde `obtenerInventario()` para poblar los botones.
- Actualizado `limpiarFiltros()` para limpiar las selecciones y sincronizar la UI tras el borrado.

### Testing
- No se ejecutaron pruebas automáticas sobre estos cambios.
- (Único resultado disponible: archivo `modificar.html` modificado y commit aplicado.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69456623311c83278d2a75c128508ed5)